### PR TITLE
Feature/case upload queue

### DIFF
--- a/api/profile/profileModel.js
+++ b/api/profile/profileModel.js
@@ -92,8 +92,8 @@ const findOrCreateProfile = async (profileObj) => {
   }
 };
 
-const add_judge_bookmark = async (user_id, judge_name) => {
-  await db('book_mark_judges').insert({ user_id, judge_name });
+const add_judge_bookmark = async (user_id, judge_id) => {
+  await db('book_mark_judges').insert({ user_id, judge_id });
   // return await db('judges').where({name: judge_name})
   return await db('book_mark_judges').where({ user_id });
 };

--- a/api/upload/uploadModel.js
+++ b/api/upload/uploadModel.js
@@ -3,15 +3,17 @@ const db = require('../../data/db-config');
 const add = async (data) => {
   return await db('pending_cases').insert(data);
 };
-
-const changeStatus = (id, newStatus) => {
-  return db('pending_cases')
+const update = async (pending_case_id, data) => {
+  return await db('pending_cases').where({ pending_case_id }).update(data);
+};
+const changeStatus = async (id, newStatus) => {
+  return await db('pending_cases')
     .where({ pending_case_id: id })
-    .first()
     .update({ status: newStatus });
 };
 
 module.exports = {
   add,
   changeStatus,
+  update,
 };


### PR DESCRIPTION
### **Changes:**
- Uploading has been sectioned out, the upload post before was one huge singular process where, when a client requests a upload the file will first be sent to the AWS S3 bucket, then right after, a call to the DS api will be made to get the scraped data back, insert the data into the BE DB and then, finally, sending back a response to the client. 
- This process has now been changed so that when a client requests a upload, the file will be sent to the S3 bucket, insert only the needed data into the BE DB(ID of the case, uploaded date, location of file in the bucket), sends back a response to the client, and then the call to the DS API will be made which will update the DB with the scraped data.
- This will allow us to more transparent with the status of a clients upload, before it was Upload -> long wait time ->Ready for Review, and now it would be Upload -> short wait time -> Processing -> medium wait time -> Ready.