### PR TITLE
bugfix/edit-case

### DIFF
--- a/api/cases/caseModel.js
+++ b/api/cases/caseModel.js
@@ -120,29 +120,7 @@ const writeCSV = async (case_id) => {
 const update = async (case_id, changes) => {
   return await db('cases')
     .where({ case_id })
-    .update(changes, [
-      'case_id',
-      'user_id',
-      'url',
-      'number',
-      'decision_date',
-      'file_name',
-      'outcome',
-      'country_of_origin',
-      'protected_grounds',
-      'application_type',
-      'case_origin_city',
-      'case_origin_state',
-      'gender',
-      'applicant_language',
-      'indigenous_group',
-      'type_of_persecution',
-      'appellate',
-      'check_for_one_year',
-      'credibility',
-      'status',
-      'comment',
-    ]);
+    .update(changes, ['*']);
 };
 
 const remove = async (case_id) => {

--- a/api/cases/caseModel.js
+++ b/api/cases/caseModel.js
@@ -118,7 +118,31 @@ const writeCSV = async (case_id) => {
 };
 
 const update = async (case_id, changes) => {
-  return await db('cases').where({ case_id }).update(changes);
+  return await db('cases')
+    .where({ case_id })
+    .update(changes, [
+      'case_id',
+      'user_id',
+      'url',
+      'number',
+      'decision_date',
+      'file_name',
+      'outcome',
+      'country_of_origin',
+      'protected_grounds',
+      'application_type',
+      'case_origin_city',
+      'case_origin_state',
+      'gender',
+      'applicant_language',
+      'indigenous_group',
+      'type_of_persecution',
+      'appellate',
+      'check_for_one_year',
+      'credibility',
+      'status',
+      'comment',
+    ]);
 };
 
 const remove = async (case_id) => {

--- a/api/cases/caseModel.js
+++ b/api/cases/caseModel.js
@@ -118,9 +118,7 @@ const writeCSV = async (case_id) => {
 };
 
 const update = async (case_id, changes) => {
-  return await db('cases')
-    .where({ case_id })
-    .update(changes, ['*']);
+  return await db('cases').where({ case_id }).update(changes, ['*']);
 };
 
 const remove = async (case_id) => {

--- a/api/cases/caseRouter.js
+++ b/api/cases/caseRouter.js
@@ -79,7 +79,8 @@ router.put('/:id', (req, res) => {
   delete req.body.first_name;
   delete req.body.middle_initial;
   delete req.body.last_name;
-  Cases.update(req.body)
+  const { id } = req.params
+  Cases.update(id, req.body)
     .then((updatedCase) => {
       res.status(200).json(updatedCase);
     })


### PR DESCRIPTION
## Description

The edit case functionality was not working when a user clicked on case details. When editing a case, the frontend was making a request to the endpoint in caseRouter.js below. I worked with folks on the frontend to make sure we were on the same page with request and response expectations.
![image](https://user-images.githubusercontent.com/81700660/133332561-ff514f3d-8705-4648-a80c-a78b94f40b61.png)
The update() model function in caseModel.js is expecting two parameters: case_id and changes and originally only the request body was being passed to update. This caused the endpoint to respond with an error with status code 500 since the update() function was not able to execute properly. After getting the case id from req.params and passing it into the update() model function as a parameter, the function was able to execute successfully. However the query in the update() model function was just returning '1' to indicate the number of records updated. Based on the Knex.js docs, I updated the query to have it return the updated case info to then be sent to the frontend so they could use it to update the frontend. 

Contributors: @schandrupatla @joshuascan @ZacharyCooremans @ctscofield 

[Corresponding frontend PR](https://github.com/Lambda-School-Labs/human-rights-first-asylum-fe-a/pull/359)

[Trello Card](https://trello.com/c/BNw1IuzJl)

[Loom Video](https://www.loom.com/share/5cf85084e2384aeda788a433b791ebde?sharedAppSource=personal_library)

Fixes status 500 error being sent to frontend when user edits a case

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have removed unnecessary comments/console logs from my code
- [] I have made corresponding changes to the documentation if necessary (optional)
- [X] My changes generate no new warnings
- [X] I have checked my code and corrected any misspellings
- [X] No duplicate code left within changed files
- [X] Size of pull request kept to a minimum
- [X] Pull request description clearly describes changes made & motivations for said changes
