### PR TITLE
Feature/judge data viz endpoint

### DIFF
--- a/api/judges/judgeRouter.js
+++ b/api/judges/judgeRouter.js
@@ -27,18 +27,12 @@ router.get('/', Cache.checkCache, (req, res) => {
 });
 
 router.get('/:judge_id/vis', async (req, res) => {
-  Judges.findById(req.params.judge_id)
-    .then((judge) => {
-      const first_name = judge['first_name']; // Current DS implementation takes first name, should refactor to query based on ID
-      axios
-        .get(`${process.env.DS_API_URL}/vis/outcome-by-judge/${first_name}`)
-        .then((data_vis_res) => {
-          const parsed_data = JSON.parse(data_vis_res.data);
-          res.status(200).json(parsed_data);
-        })
-        .catch((err) => {
-          res.status(500).json({ message: err.message });
-        });
+  const { judge_id } = req.params;
+  axios
+    .get(`${process.env.DS_API_URL}/vis/judge/${judge_id}`)
+    .then((data_vis_res) => {
+      const parsed_data = JSON.parse(data_vis_res.data);
+      res.status(200).json(parsed_data);
     })
     .catch((err) => {
       res.status(500).json({ message: err.message });

--- a/api/judges/judgeRouter.js
+++ b/api/judges/judgeRouter.js
@@ -15,19 +15,6 @@ const upload = multer({ dest: 'uploads/' });
 const router = express.Router();
 const { uploadFile, getFileStream } = require('./s3');
 
-const getCircularReplacer = () => {
-  const seen = new WeakSet();
-  return (key, value) => {
-    if (typeof value === "object" && value !== null) {
-      if (seen.has(value)) {
-        return;
-      }
-      seen.add(value);
-    }
-    return value;
-  };
-};
-
 router.use('/:judge_id', verify.verifyJudgeId);
 
 router.get('/', Cache.checkCache, (req, res) => {
@@ -44,6 +31,18 @@ router.get('/:judge_id/vis', async (req, res) => {
   axios
     .get(`${process.env.DS_API_URL}/vis/judge/${judge_id}`)
     .then((data_vis_res) => {
+      const getCircularReplacer = () => {
+        const seen = new WeakSet();
+        return (key, value) => {
+          if (typeof value === 'object' && value !== null) {
+            if (seen.has(value)) {
+              return;
+            }
+            seen.add(value);
+          }
+          return value;
+        };
+      };
       const data = JSON.stringify(data_vis_res.data, getCircularReplacer());
       const parsed_data = JSON.parse(data);
       res.status(200).json(parsed_data);


### PR DESCRIPTION
## Description

The endpoint passing the data visualization info from the DS API to the frontend (/judges/2/vis) was broken so the data visualization was not appearing. Originally the endpoint was based on a judge's name and is now updated to be based on judge_id pulled from req.params which is what the DS API endpoint is expecting. 

Working closely with DS, backend, and frontend and redeploying the DS API we were still receiving the following error when trying to make a request to the DS endpoint:
```
"Converting circular structure to JSON\n --> starting at object with constructor 'ClientRequest'\n | property 'socket' -> object with constructor 'Socket'\n --- property '_httpMessage' closes the circle"

```
The error seemed to be on the backend since the DS API was showing successful requests.
Googling the error I came across the [getCircularReplacer() function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Errors/Cyclic_object_value) which resolved this error.

** Currently the authRequired middleware has been removed to bypass an error we were receiving regarding tokens but please do let me know if keeping this removed before merging could be a security risk.

Contributors: @lucaschatham @leecrowe @schandrupatla @chrisjs87 Please let me know if I forgot anyone!

[Trello Card](https://trello.com/c/qAuXVBzy)
[Loom Video](https://www.loom.com/share/36a5c465f8614309bec248f6a25f5648?sharedAppSource=personal_library)

Fixes the backend endpoint /judges/2/vis that sends data visualization from the DS API to the frontend to receive and render judge data visualizations.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have removed unnecessary comments/console logs from my code
- [ ] I have made corresponding changes to the documentation if necessary (optional)
- [X] My changes generate no new warnings
- [X] I have checked my code and corrected any misspellings
- [X] No duplicate code left within changed files
- [X] Size of pull request kept to a minimum
- [X] Pull request description clearly describes changes made & motivations for said changes
